### PR TITLE
Enable Equation Wrapping for MathJax

### DIFF
--- a/CosineTest10.html
+++ b/CosineTest10.html
@@ -238,6 +238,18 @@
       color: #b71c1c;
     }
     /* End enhancements */
+    
+    /* MathJax equation wrapping */
+    .MathJax_Display, .mjx-block {
+      white-space: normal !important;
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      width: 100% !important;
+      box-sizing: border-box;
+    }
+    .MathJax, .math.inline {
+      white-space: normal !important;
+    }
   </style>
   <script
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"

--- a/NewOutput.html
+++ b/NewOutput.html
@@ -239,6 +239,18 @@
       color: #b71c1c;
     }
     /* End enhancements */
+
+    /* MathJax equation wrapping */
+    .MathJax_Display, .mjx-block {
+      white-space: normal !important;
+      overflow-wrap: break-word;
+      word-wrap: break-word;
+      width: 100% !important;
+      box-sizing: border-box;
+    }
+    .MathJax, .math.inline {
+      white-space: normal !important;
+    }
   </style>
   <script
   src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml-full.js"


### PR DESCRIPTION
This PR modifies the CSS for displaying MathJax equations in CosineTest10.html and NewOutput.html to ensure that long equations wrap within the display area. The changes include setting `white-space` to normal and adding properties for `overflow-wrap` and `word-wrap`. This allows for better visibility and prevents overflow issues when equations are displayed.

---

> This pull request was co-created with Cosine Genie

Original Task: [MiwokApp/lk8t9wmf6lv4](https://cosine.sh/qkq7o6t16ech/MiwokApp/task/lk8t9wmf6lv4)
Author: Rex Donahey
